### PR TITLE
AutoCloseable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/DatabaseConnection.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseConnection.java
@@ -8,7 +8,7 @@ import liquibase.exception.DatabaseException;
  * connection.
  * 
  */
-public interface DatabaseConnection {
+public interface DatabaseConnection extends AutoCloseable {
 
     public void close() throws DatabaseException;
 


### PR DESCRIPTION
I believe that every single Java class/interface that shows a close() method should extend AutoCloseable so that 1) it can be instantiated in a try-with-resources block and 2) raise a compiler warning (e.g. with Eclipse) if not disposed properly of
